### PR TITLE
fix invalid page tokens for entities without ids

### DIFF
--- a/chron-db/src/models.rs
+++ b/chron-db/src/models.rs
@@ -132,7 +132,7 @@ impl FromStr for PageToken {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let engine = base64::engine::general_purpose::URL_SAFE;
         let data = engine.decode(s)?;
-        if data.len() <= 16 {
+        if data.len() < 9 { // 8 byte timestamp + minimum 1 byte entity id
             return Err(anyhow::anyhow!("invalid page token"));
         }
 


### PR DESCRIPTION
entities such as `Time` and `State` don't have IDs, so they're given a dummy ID which happens to be significantly shorter than normal. this means the page token is shorter than the expected 16 byte minimum, but is otherwise valid

(please test this. i made this pr on my phone with the GitHub web editor)